### PR TITLE
Feature/tab-menu 탭메뉴 UI 수정 및 버그 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,23 +1,27 @@
 <template>
-    <Toast position="top-center" class="promptly-toast" />
-    <div class="tab-header">
-      <Button
-          text
-          label="MAIN"
-          @click="activeTab = 'main'"
-          :class="{'active': activeTab === 'main'}"
-      />
-      <Button
-          text
-          label="MANAGE"
-          @click="activeTab = 'manage'"
-          :class="{'active': activeTab === 'manage'}"
-      />
+  <Toast position="top-center" class="promptly-toast" />
+  <div class="custom-tabmenu">
+    <div
+      class="tab-item"
+      :class="{ active: activeIndex === 0 }"
+      @click="activeIndex = 0"
+    >
+      <i class="pi pi-home icon-spacing"></i>
+      <span>MAIN</span>
     </div>
-    <div class="tab-content">
-      <MainPage v-if="activeTab === 'main'" />
-      <PromptManagementPage v-else />
+    <div
+      class="tab-item"
+      :class="{ active: activeIndex === 1 }"
+      @click="activeIndex = 1"
+    >
+      <i class="pi pi-pencil icon-spacing"></i>
+      <span>MANAGE</span>
     </div>
+  </div>
+  <div class="tab-content">
+    <MainPage v-if="activeIndex === 0" />
+    <PromptManagementPage v-else />
+  </div>
 </template>
 
 <script>
@@ -32,73 +36,64 @@ export default {
   },
   data() {
     return {
-      activeTab: 'main',
+      activeIndex: 0,
     };
   },
 };
 </script>
 
 <style>
+@import 'primeicons/primeicons.css';
+
 #app {
-  min-width: 400px;
   min-height: 600px;
-  width: 100%;
-  height: 100%;
+  width: 400px;
   overflow: hidden;
   position: relative;
 }
 
-/* 탭 헤더 스타일 */
-.tab-header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  background-color: white;
-  z-index: 1;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
-  border-bottom: 1px solid #ccc;
-}
-
-/* 탭 콘텐츠 영역 */
-.tab-content {
-  position: absolute;
-  top: 60px; /* 헤더의 높이만큼 아래로 */
-  bottom: 0;
-  left: 0;
-  right: 0;
-  overflow-y: auto;
-  padding: 10px;
-}
-
-/* 선택된 탭 버튼 스타일 */
-.tab-header .active,
-.tab-header .active:hover {
-  font-weight: bold;
-  border-bottom: 2px solid var(--p-button-text-primary-color) !important;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-  color: var(--p-button-text-primary-color) !important;
-}
-
-@media (prefers-color-scheme: dark) {
-  #app {
-    background-color:#0A0A0B;
-  }
-
-  .tab-header {
-    background-color: #0A0A0B;
-    border-bottom: 1px solid #666;
-  }
-
-  .tab-header .active {
-    color: #007ad9;
-  }
-}
-
 .promptly-toast {
   --p-toast-width: 90%;
+}
+
+.custom-tabmenu {
+  display: flex;
+  width: 100%;
+  cursor: pointer;
+}
+
+.tab-item {
+  flex: 1;
+  padding: 10px;
+  text-align: center;
+  color: var(--p-button-text-primary-color);
+  border-bottom: 2px solid transparent;
+  opacity: 0.4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tab-item i {
+  display: flex;
+  align-items: center;
+}
+
+.tab-item span {
+  padding-top: 2px;
+}
+
+.tab-item.active {
+  color: var(--p-button-text-primary-color);
+  border-bottom: 2px solid var(--p-button-text-primary-color);
+  opacity: 1;
+}
+
+.icon-spacing {
+  margin-right: 8px;
+}
+
+.tab-content {
+  padding: 10px;
 }
 </style>

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -153,7 +153,7 @@ export default {
       if (newPrompt) {
         const varMatches = newPrompt.match(/{(.*?)}/g);
         variables.value = varMatches
-            ? varMatches.map((v) => v.replace(/[{}]/g, ''))
+            ? [...new Set(varMatches.map((v) => v.replace(/[{}]/g, '')))]
             : [];
         variables.value.forEach((variable) => {
           userInputs[variable] = '';

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -17,13 +17,12 @@
             class="p-field variable-field"
         >
           <label :for="'var_' + index">{{ variable }} {{ getMessage('inputLabel') }}:</label>
-          <component
-              :is="userInputs[variable].length > 50 ? 'Textarea' : 'InputText'"
+          <Textarea
               v-model="userInputs[variable]"
               :id="'var_' + index"
-              :rows="userInputs[variable].length > 50 ? 3 : 1"
-              autoResize
               class="variable-input"
+              autoResize
+              rows="1"
           />
         </div>
       </div>
@@ -246,6 +245,9 @@ export default {
 
 .variable-input {
   width: 100%;
+  line-height: 1.5em;
+  overflow-y: auto !important;
+  max-height: calc(1.5em * 3);
 }
 
 .dropdown-container {

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -10,7 +10,6 @@
           style="width: 100%; margin-bottom: 1rem;"
           append-to="self"
       />
-
       <div v-if="variables.length" class="variables-container">
         <div
             v-for="(variable, index) in variables"

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -269,14 +269,12 @@ export default {
 
 .textarea {
   width: 100%;
-  max-width: 600px;
 }
 
 .button-group {
   display: flex;
   align-items: center;
   width: 100%;
-  max-width: 600px;
   margin-top: 0.5em;
   position: relative;
 }
@@ -309,7 +307,6 @@ export default {
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 600px;
   gap: 1em;
   list-style: none;
   padding: 0;

--- a/src/composables/useChromeI18n.js
+++ b/src/composables/useChromeI18n.js
@@ -24,7 +24,7 @@ export default function useI18n() {
   };
 
   function getLocale() {
-    if (isChromeI18nAvailable) {
+    if (isChromeI18nAvailable.value) {
       return chrome.i18n.getUILanguage();
     } else {
       // Local 개발 환경에서는 한국어 사용


### PR DESCRIPTION
### 변경 사항
- 기존의 버튼 형태로 구현되어 어색했던 탭 메뉴를 더 자연스럽고 직관적인 디자인으로 개선했습니다.
- `useChromeI18n`에서 `ref()`로 감싼 변수 사용 방식에 오류가 있어 이를 수정했습니다.
- 긴 프롬프트를 선택했을 때 가로 너비가 변동되는 문제가 있어 가로 너비를 `400px`로 고정했습니다.
- MAIN에서 변수 값의 길이에 따라 `Textarea`와 `InputText`를 혼용하던 중, 두 컴포넌트가 교체될 때 포커스가 사라지는 문제가 발생하여 이를 해결했습니다. 이제 1줄에서 3줄까지 자동으로 조절되는 `Textarea`만을 사용합니다.

![스크린샷 2024-11-29 오후 10 32 50](https://github.com/user-attachments/assets/6e9eb3bc-98c1-4ec2-8c8c-9831db1599cf) ![스크린샷 2024-11-29 오후 10 33 24](https://github.com/user-attachments/assets/7ecc2a9d-e6b1-459d-bcb8-09aed1e54304)


### To reviewers
- PrimeVue의 탭 메뉴 컴포넌트로는 좌측 정렬된 탭 메뉴만 구현이 가능하고, 현재처럼 너비가 꽉 차는 탭 메뉴를 구현할 수 없어서 직접 `div`로 커스텀 구현했습니다.
