### PR TITLE
Feature/initialPromptBugFix 첫 실행에만 샘플 프로젝트에 프롬프트의 id가 노출되는 문제 수정

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "promptly",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Chrome extension for managing prompt templates and delivering them to AI services.",
   "action": {
     "default_popup": "index.html",

--- a/src/composables/useChromeStorage.js
+++ b/src/composables/useChromeStorage.js
@@ -75,11 +75,7 @@ export default function useChromeStorage() {
                         "(Sample) Write an effective marketing strategy for {product} targeting the {target market}. The main goal is {goal}."
                     ];
                 }
-                // 프롬프트를 객체 배열로 변환하여 'prompts.value'에 저장
-                prompts.value = defaultPrompts.map((text, idx) => ({
-                    id: Date.now() + idx,
-                    text,
-                }));
+                prompts.value = defaultPrompts;
                 await set({prompts: defaultPrompts, hasUsedBefore: true});
             } else {
                 if (Array.isArray(data.prompts)) {


### PR DESCRIPTION
### 변경 사항
- 첫 실행시에 샘플 프롬프트와 함께 id가 노출되는 문제를 수정했습니다.
   - 원인: id는 manage 에서 애니메이션 구현을 위해서 필요한데, main에서는 필요가 없음에도 첫 실행시에 샘플 프롬프트가 만들어지면서 id가 같이 부여되는게 원인이었습니다.
   - 참고: storage에는 id없이 프롬프트가 저장되기 때문에 첫 실행 이후에는 재현되지 않습니다.
