### PR TITLE
Feature/#25 

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -106,5 +106,8 @@
     },
     "storageSyncErrorMessage": {
         "message": "Storage capacity has been exceeded, please reduce the length or number of prompts."
+    },
+    "contextMenuAddSelectedTextAsPrompt": {
+        "message": "Add selected text as a prompt"
     }
 }

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -106,5 +106,8 @@
     },
     "storageSyncErrorMessage": {
         "message": "저장 용량을 초과하여 저장할 수 없습니다. 프롬프트의 길이 또는 개수를 줄여주세요."
+    },
+    "contextMenuAddSelectedTextAsPrompt": {
+        "message" : "선택한 텍스트를 프롬프트로 추가"
     }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,7 +12,10 @@
       "128": "icons/appicon_blue_128.png"
     }
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "contextMenus"],
+  "background": {
+    "service_worker": "worker.js"
+  },
   "icons": {
     "128": "icons/appicon_blue_128.png"
   },

--- a/public/worker.js
+++ b/public/worker.js
@@ -1,0 +1,24 @@
+const menuIds = {
+  addSelectedTextAsPrompt: "addSelectedTextAsPrompt"
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: menuIds.addSelectedTextAsPrompt,
+    title: chrome.i18n.getMessage("contextMenuAddSelectedTextAsPrompt"),
+    contexts: ["selection"]
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === menuIds.addSelectedTextAsPrompt && info.selectionText) {
+    onClickAddSelectedTextAsPrompt(info, tab);
+  }
+  // 다른 메뉴가 추가된다면 여기에 분기를 추가
+});
+
+function onClickAddSelectedTextAsPrompt(info, tab) {
+  chrome.action.openPopup().then(() => {
+    chrome.runtime.sendMessage({type: "addPrompt", data: info.selectionText});
+  });
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,26 +20,26 @@
   </div>
   <div class="tab-content">
     <MainPage v-if="activeIndex === 0" />
-    <PromptManagementPage v-else />
+    <PromptManagementPage ref="promptManagementPage" v-else />
   </div>
 </template>
 
-<script>
+<script setup>
 import MainPage from './components/MainPage.vue';
 import PromptManagementPage from './components/PromptManagementPage.vue';
+import {nextTick, ref, useTemplateRef} from "vue";
 
-export default {
-  name: 'App',
-  components: {
-    MainPage,
-    PromptManagementPage,
-  },
-  data() {
-    return {
-      activeIndex: 0,
-    };
-  },
-};
+const activeIndex = ref(0)
+const promptManagementPage = useTemplateRef('promptManagementPage')
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === "addPrompt" && msg.data !== "") {
+    activeIndex.value = 1
+    nextTick(() => {
+      promptManagementPage.value.handleAddPromptFromContext(msg.data)
+    })
+  }
+});
 </script>
 
 <style>

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -319,18 +319,9 @@ export default {
 
     function handleAddPromptFromContext(prompt) {
       storage.loadPrompts().then(() => {
-        const newPromptObj = { id: Date.now(), text: prompt };
-        const newPrompts = prompts.value.concat(newPromptObj);
-
-        updateStorePrompts(newPrompts, getMessage('addPromptMessage'))
-            .then(() => {
-              prompts.value.push(newPromptObj);
-              console.log('Prompt added from contextmenu successfully');
-            })
-            .catch((error) => {
-              console.error('Failed to add from contextmenu prompt:', error);
-            });
-        })
+        newPrompt.value = prompt;
+        addPrompt();
+      })
     }
 
     return {

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -317,6 +317,22 @@ export default {
       }
     };
 
+    function handleAddPromptFromContext(prompt) {
+      storage.loadPrompts().then(() => {
+        const newPromptObj = { id: Date.now(), text: prompt };
+        const newPrompts = prompts.value.concat(newPromptObj);
+
+        updateStorePrompts(newPrompts, getMessage('addPromptMessage'))
+            .then(() => {
+              prompts.value.push(newPromptObj);
+              console.log('Prompt added from contextmenu successfully');
+            })
+            .catch((error) => {
+              console.error('Failed to add from contextmenu prompt:', error);
+            });
+        })
+    }
+
     return {
       prompts,
       newPrompt,
@@ -341,6 +357,7 @@ export default {
       hoveredIndex,
       loaded: storage.loaded,
       getMessage,
+      handleAddPromptFromContext,
     };
   },
 };


### PR DESCRIPTION
Close #25 
- `menifest.json`에 `contextMenus`권한 추가
- contextmenu 추가
  - 백그라운드 스크립트의 onInstalled 훅에서 추가됩니다
- background script 추가
  - contextmenu 메뉴추가나 popup을 표시하는 등의 활동은 background의 서비스워커 스크립트에서 실행되어야 해서 추가되었습니다
  - popup화면과 서비스 워커의 통신을 위해 `chrome.runtime.sendMessage`, `chrome.runtime.onMessage`를 사용합니다
  - 순서
    1. 사용자가 contextmenu에서 클릭
    2. 서비스 워커에서 클릭 핸들러 실행되어 팝업을 열고 텍스트를 메시지로 전송
    3. `App.vue`에서 메시지를 받으면 페이지를 관리로 변경 후 `PromptManagementPage.vue`의 핸들러 함수를 호출
    4. `PromptManagementPage.vue`의 핸들러는 프롬프트 추가 로직을 실행
