### PR TITLE
Feature/#27 검색 기능 프롬프트 수정창의 textarea 크기 조정 더이상 서비스 되지 않는 모델 삭제 (gpt-4 canmore) 등

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <Toast position="top-center" class="promptly-toast" />
+  <Toast position="bottom-center" class="promptly-toast" />
   <div class="custom-tabmenu">
     <div
       class="tab-item"

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -9,6 +9,8 @@
           :placeholder="getMessage('selectPromptLabel')"
           style="width: 100%; margin-bottom: 1rem;"
           append-to="self"
+          filter
+          showClear
       />
       <div v-if="variables.length" class="variables-container">
         <div

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -99,12 +99,11 @@ export default {
 
     // 모델 옵션들
     const modelOptions = [
-      {label: 'ChatGPT 4', model: 'gpt-4'},
       {label: 'ChatGPT 4o', model: 'gpt-4o'},
-      {label: 'ChatGPT 4o mini', model: 'gpt-4o-mini'},
-      {label: 'ChatGPT 4o with canvas', model: 'gpt-4o-canmore'},
       {label: 'ChatGPT o1', model: 'o1'},
       {label: 'ChatGPT o1-mini', model: 'o1-mini'},
+      {label: 'ChatGPT 4o mini', model: 'gpt-4o-mini'},
+      {label: 'ChatGPT 4', model: 'gpt-4'},
       {separator: true},
       {label: 'Claude 3.5 Sonnet', model: 'Claude 3.5 Sonnet'},
       {separator: true},

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container" v-if="loaded">
-    <Textarea v-model="newPrompt" rows="3" cols="30" :placeholder="getMessage('addPromptLabelPlaceholder')" class="textarea" />
+    <Textarea v-model="newPrompt" rows="3" cols="30" :placeholder="getMessage('addPromptLabelPlaceholder')" class="textarea" autoResize/>
     <div class="button-group">
       <Button :label="getMessage('addPromptLabel')" @click="addPrompt" class="add-button" />
       <Menu :model="menuItems" popup ref="menu" />
@@ -350,6 +350,7 @@ export default {
 
 .textarea {
   width: 100%;
+  max-height: 30em;
 }
 
 .button-group {


### PR DESCRIPTION
### 변경사항
- 프롬프트 검색 기능을 추가하였습니다.
- 프롬프트를 해제 할 수 있도록 `showClear`  를 추가했습니다.
- 프롬프트 수정창의 textarea의 높이가 작성된 텍스트에 따라 최대 `30em`까지 늘어나도록 수정했습니다.
- 더 이상 서비스 되지 않는 모델을 삭제했습니다. (gpt-4 canmore)
- 모델의 정렬 순서를 chatgpt와 동일하게 변경했습니다.
- toast의 위치를 아래로 변경하였습니다.


### To reviewers
- 쿼리 파람으로 model을 넘기고 있는데, `12 days` 동안 동작하지 않더니 이제 정상적으로 동작하네요!