### PR TITLE
프롬프트에 제목 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@primevue/themes": "^4.2.2",
+    "nanoid": "^5.0.9",
     "primeicons": "^6.0.1",
     "primevue": "^4.2.2",
     "vue": "^3.0.0",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -17,6 +17,9 @@
     "copyLabel": {
         "message": "Copy"
     },
+    "addPromptTitlePlaceholder": {
+        "message": "Title"
+    },
     "addPromptLabelPlaceholder": {
         "message": "Create a new prompt with {variable}!"
     },

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -17,6 +17,9 @@
     "copyLabel": {
         "message": "복사"
     },
+    "addPromptTitlePlaceholder": {
+        "message": "제목"
+    },
     "addPromptLabelPlaceholder": {
         "message": "{변수}를 포함해 새 프롬프트를 작성해보세요!"
     },

--- a/public/worker.js
+++ b/public/worker.js
@@ -22,6 +22,9 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 function onClickAddSelectedTextAsPrompt(info, tab) {
   chrome.action.openPopup().then(() => {
-    chrome.runtime.sendMessage({ type: "addPrompt", data: info.selectionText });
+    chrome.runtime.sendMessage({
+      type: "addPrompt",
+      data: info.selectionText,
+    });
   });
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -27,18 +27,20 @@
 <script setup>
 import MainPage from "./components/MainPage.vue";
 import PromptManagementPage from "./components/PromptManagementPage.vue";
-import { nextTick, ref, useTemplateRef } from "vue";
+import { nextTick, onMounted, ref, useTemplateRef } from "vue";
 
 const activeIndex = ref(0);
 const promptManagementPage = useTemplateRef("promptManagementPage");
 
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.type === "addPrompt" && msg.data !== "") {
-    activeIndex.value = 1;
-    nextTick(() => {
-      promptManagementPage.value.handleAddPromptFromContext(msg.data);
-    });
-  }
+onMounted(() => {
+  chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg.type === "addPrompt" && msg.data !== "") {
+      activeIndex.value = 1;
+      nextTick(() => {
+        promptManagementPage.value.handleAddPromptFromContext(msg.data);
+      });
+    }
+  });
 });
 </script>
 

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -188,7 +188,7 @@ export default {
     });
 
     const prompts = computed(() => {
-      return storage.prompts.value.map(updatePrompt).map(addId);
+      return storage.prompts.value.map(addId);
     });
 
     function findPromptById(id) {

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -2,16 +2,29 @@
   <div class="container">
     <div class="dropdown-container">
       <Select
-        v-model="selectedPrompt"
+        v-model="selectedPromptId"
         :options="prompts"
-        option-label="text"
-        option-value="value"
+        option-label="title"
+        option-value="id"
+        :label-style="{ 'font-weight': 'bold' }"
         :placeholder="getMessage('selectPromptLabel')"
         style="width: 100%; margin-bottom: 1rem"
         append-to="self"
         filter
+        :filter-fields="['title', 'text']"
         showClear
-      />
+      >
+        <template style="flex-direction: column" #option="optionData">
+          <div class="prompt-option">
+            <p class="prompt-option-title">
+              {{ optionData.option.title }}
+            </p>
+            <span class="prompt-option-text">
+              {{ optionData.option.text }}
+            </span>
+          </div>
+        </template>
+      </Select>
       <div v-if="variables.length" class="variables-container">
         <div
           v-for="(variable, index) in variables"
@@ -35,7 +48,7 @@
       <Button
         :label="getMessage('viewResultLabel')"
         class="result-button"
-        :disabled="!selectedPrompt"
+        :disabled="!selectedPromptId"
         @click="generatePrompt"
       />
     </div>
@@ -93,6 +106,7 @@ import { useToast } from "primevue/usetoast";
 import useChromeStorage from "../composables/useChromeStorage";
 import useI18n from "../composables/useChromeI18n";
 import { getStringBytes } from "../utils/stringUtils";
+import { addId, updatePrompt } from "../utils/promptConverter";
 
 export default {
   name: "MainPage",
@@ -100,7 +114,7 @@ export default {
     const storage = useChromeStorage();
     const { getMessage } = useI18n();
     const toast = useToast();
-    const selectedPrompt = ref(null);
+    const selectedPromptId = ref(null);
     const variables = ref([]);
     const userInputs = reactive({});
     const filledPrompt = ref("");
@@ -163,9 +177,9 @@ export default {
     onMounted(() => {
       storage
         .get("selectedModel")
-        .then((data) => {
-          if (data.selectedModel) {
-            selectedModel.value = data.selectedModel;
+        .then((model) => {
+          if (model) {
+            selectedModel.value = model;
           }
         })
         .catch((error) => {
@@ -174,15 +188,17 @@ export default {
     });
 
     const prompts = computed(() => {
-      return storage.prompts.value.map((prompt, index) => ({
-        text: prompt,
-        value: prompt,
-        id: index,
-      }));
+      return storage.prompts.value.map(updatePrompt).map(addId);
     });
 
-    watch(selectedPrompt, (newPrompt) => {
-      if (newPrompt) {
+    function findPromptById(id) {
+      return prompts.value.find((prompt) => prompt.id === id);
+    }
+
+    watch(selectedPromptId, (selectedPromptId) => {
+      console.log(selectedPromptId);
+      if (selectedPromptId) {
+        const newPrompt = findPromptById(selectedPromptId).text;
         const varMatches = newPrompt.match(/{(.*?)}/g);
         variables.value = varMatches
           ? [...new Set(varMatches.map((v) => v.replace(/[{}]/g, "")))]
@@ -201,8 +217,8 @@ export default {
     }
 
     const generatePrompt = () => {
-      if (selectedPrompt.value) {
-        let tempPrompt = selectedPrompt.value;
+      if (selectedPromptId.value) {
+        let tempPrompt = findPromptById(selectedPromptId.value)?.text ?? "";
         variables.value.forEach((variable) => {
           const value = userInputs[variable] || "";
           const escapedVariable = escapeRegExp(variable);
@@ -255,7 +271,7 @@ export default {
 
     return {
       prompts,
-      selectedPrompt,
+      selectedPromptId,
       variables,
       userInputs,
       generatePrompt,
@@ -276,6 +292,27 @@ export default {
 <style scoped>
 .p-field {
   margin-top: 1em;
+}
+
+.prompt-option {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+.prompt-option-title {
+  width: 100%;
+  margin: 0;
+  font-weight: bold;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.prompt-option-text {
+  width: 100%;
+  margin: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .variable-input {

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -196,7 +196,6 @@ export default {
     }
 
     watch(selectedPromptId, (selectedPromptId) => {
-      console.log(selectedPromptId);
       if (selectedPromptId) {
         const newPrompt = findPromptById(selectedPromptId).text;
         const varMatches = newPrompt.match(/{(.*?)}/g);

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -447,7 +447,6 @@ export default {
     function handleAddPromptFromContext(prompt) {
       storage.loadPrompts().then(() => {
         newPrompt.value = prompt;
-        addPrompt();
       });
     }
 

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -223,6 +223,7 @@ export default {
             console.error("Failed to add prompt:", error);
           });
         newPrompt.value = "";
+        newTitle.value = "";
       }
     };
 

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -276,7 +276,7 @@ export default {
 
     const duplicatePrompt = (index) => {
       const promptToDuplicate = {
-        ...structuredClone(prompts.value[index]),
+        ...prompts.value[index],
         id: nanoid(),
       };
       const newPrompts = prompts.value.slice();

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -1,5 +1,10 @@
 <template>
   <div v-if="loaded" class="container">
+    <InputText
+      v-model="newTitle"
+      class="new-title-input"
+      :placeholder="getMessage('addPromptTitlePlaceholder')"
+    />
     <Textarea
       v-model="newPrompt"
       rows="3"
@@ -62,6 +67,7 @@
       >
         <div class="prompt-content">
           <div v-if="editingIndex === index" class="edit-mode">
+            <InputText class="title-edit" v-model="editedTitle" />
             <Textarea
               v-model="editedPrompt"
               rows="3"
@@ -85,6 +91,7 @@
           </div>
           <div v-else class="view-mode">
             <div class="prompt-text-wrapper">
+              <p class="prompt-title">{{ prompt.title }}</p>
               <p class="prompt-text">{{ prompt.text }}</p>
               <transition name="fade">
                 <div
@@ -147,6 +154,14 @@ import Menu from "primevue/menu";
 import Dialog from "primevue/dialog";
 import useChromeStorage from "../composables/useChromeStorage";
 import useI18n from "../composables/useChromeI18n";
+import {
+  addId,
+  convertImportedPrompt,
+  convertPromptToExport,
+  convertPromptToStore,
+  updatePrompt,
+} from "../utils/promptConverter";
+import { nanoid } from "nanoid";
 
 export default {
   name: "PromptManagementPage",
@@ -157,7 +172,9 @@ export default {
   setup() {
     const storage = useChromeStorage();
     const { getMessage } = useI18n();
+    const newTitle = ref("");
     const newPrompt = ref("");
+    const editedTitle = ref("");
     const editedPrompt = ref("");
     const editingIndex = ref(-1);
     const fileInput = ref(null);
@@ -172,10 +189,7 @@ export default {
 
     // 데이터 로드 완료 상태
     storage.loadPrompts().then(() => {
-      prompts.value = storage.prompts.value.map((text, idx) => ({
-        id: Date.now() + idx,
-        text,
-      }));
+      prompts.value = storage.prompts.value.map(updatePrompt);
     });
 
     const menuItems = [
@@ -192,8 +206,12 @@ export default {
     ];
 
     const addPrompt = () => {
-      if (newPrompt.value.trim()) {
-        const newPromptObj = { id: Date.now(), text: newPrompt.value.trim() };
+      if (newPrompt.value.trim() && newTitle.value.trim()) {
+        const newPromptObj = {
+          id: nanoid(),
+          text: newPrompt.value.trim(),
+          title: newTitle.value.trim(),
+        };
         const newPrompts = prompts.value.concat(newPromptObj);
 
         updateStorePrompts(newPrompts, getMessage("addPromptMessage"))
@@ -211,6 +229,7 @@ export default {
     const editPrompt = (index) => {
       editingIndex.value = index;
       editedPrompt.value = prompts.value[index].text;
+      editedTitle.value = prompts.value[index].title;
     };
 
     const saveEditedPrompt = (index) => {
@@ -218,13 +237,14 @@ export default {
         const updatedPrompt = {
           ...prompts.value[index],
           text: editedPrompt.value.trim(),
+          title: editedTitle.value,
         };
         const newPrompts = prompts.value.slice();
         newPrompts.splice(index, 1, updatedPrompt);
 
         updateStorePrompts(newPrompts, getMessage("updatePromptMessage"))
           .then(() => {
-            prompts.value[index].text = editedPrompt.value.trim();
+            prompts.value[index] = updatedPrompt;
             editingIndex.value = -1;
             console.log("Prompt updated successfully");
           })
@@ -237,6 +257,7 @@ export default {
     const cancelEdit = () => {
       editingIndex.value = -1; // 편집 모드 종료
       editedPrompt.value = ""; // 수정 중인 프롬프트 초기화
+      editedTitle.value = ""; // 수정 중인 프롬프트 초기화
     };
 
     const deletePrompt = (index) => {
@@ -255,8 +276,8 @@ export default {
 
     const duplicatePrompt = (index) => {
       const promptToDuplicate = {
-        id: Date.now(),
-        text: prompts.value[index].text,
+        ...structuredClone(prompts.value[index]),
+        id: nanoid(),
       };
       const newPrompts = prompts.value.slice();
       newPrompts.splice(index + 1, 0, promptToDuplicate);
@@ -273,7 +294,7 @@ export default {
 
     const exportPrompts = () => {
       const dataStr = JSON.stringify(
-        prompts.value.map((p) => p.text),
+        prompts.value.map(convertPromptToExport),
         null,
         2,
       );
@@ -299,10 +320,7 @@ export default {
         reader.onload = (e) => {
           try {
             const parsedPrompts = JSON.parse(e.target.result);
-            if (
-              Array.isArray(parsedPrompts) &&
-              parsedPrompts.every((item) => typeof item === "string")
-            ) {
+            if (Array.isArray(parsedPrompts)) {
               importedPrompts.value = parsedPrompts;
               dialogVisible.value = true; // 대화창 표시
             } else {
@@ -324,10 +342,9 @@ export default {
     };
 
     const overwritePrompts = () => {
-      const newPrompts = importedPrompts.value.map((text, idx) => ({
-        id: Date.now() + idx,
-        text,
-      }));
+      const newPrompts = importedPrompts.value
+        .map(convertImportedPrompt)
+        .map(addId);
 
       updateStorePrompts(newPrompts, getMessage("overwritePromptMessage"))
         .then(() => {
@@ -341,10 +358,9 @@ export default {
     };
 
     const appendPrompts = () => {
-      const importedWithIds = importedPrompts.value.map((text, idx) => ({
-        id: Date.now() + prompts.value.length + idx,
-        text,
-      }));
+      const importedWithIds = importedPrompts.value
+        .map(convertImportedPrompt)
+        .map(addId);
       const newPrompts = prompts.value.concat(importedWithIds);
 
       updateStorePrompts(newPrompts, getMessage("appendPromptMessage"))
@@ -403,7 +419,7 @@ export default {
     };
 
     const updateStorePrompts = async (newPrompts, message) => {
-      const promptsTexts = newPrompts.map((prompt) => prompt.text);
+      const promptsTexts = newPrompts.map(convertPromptToStore);
       try {
         await storage.set({ prompts: promptsTexts });
         storage.prompts.value = promptsTexts;
@@ -436,6 +452,7 @@ export default {
 
     return {
       prompts,
+      newTitle,
       newPrompt,
       addPrompt,
       editPrompt,
@@ -447,6 +464,7 @@ export default {
       onFileChange,
       overwritePrompts,
       appendPrompts,
+      editedTitle,
       editedPrompt,
       editingIndex,
       menuItems,
@@ -465,6 +483,11 @@ export default {
 </script>
 
 <style scoped>
+.new-title-input {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
 .textarea {
   width: 100%;
   max-height: 30em;
@@ -525,11 +548,16 @@ export default {
   position: relative;
 }
 
+.prompt-title {
+  font-weight: bold;
+  margin-top: 0;
+}
+
 .prompt-text {
   margin: 0;
   word-wrap: break-word;
   font-size: 1em;
-  padding: 1rem;
+  padding: 0.25rem 1rem 1rem 1rem;
 }
 
 .prompt-actions-overlay {
@@ -560,6 +588,11 @@ export default {
 
 .prompt-card:hover .prompt-actions {
   opacity: 1;
+}
+
+.title-edit {
+  width: 100%;
+  margin-bottom: 0.5rem;
 }
 
 .input-edit {

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -237,7 +237,7 @@ export default {
         const updatedPrompt = {
           ...prompts.value[index],
           text: editedPrompt.value.trim(),
-          title: editedTitle.value,
+          title: editedTitle.value.trim(),
         };
         const newPrompts = prompts.value.slice();
         newPrompts.splice(index, 1, updatedPrompt);

--- a/src/composables/useChromeStorage.js
+++ b/src/composables/useChromeStorage.js
@@ -1,5 +1,6 @@
 import { ref } from "vue";
 import useI18n from "./useChromeI18n";
+import { nanoid } from "nanoid";
 
 export default function useChromeStorage() {
   const { getLocale } = useI18n();
@@ -17,14 +18,14 @@ export default function useChromeStorage() {
           if (chrome.runtime.lastError) {
             reject(chrome.runtime.lastError);
           } else {
-            resolve(result);
+            resolve(result[key]);
           }
         });
       } else {
         try {
           const data = {};
           data[key] = JSON.parse(localStorage.getItem(key));
-          resolve(data);
+          resolve(data[key]);
         } catch (error) {
           reject(error);
         }
@@ -58,33 +59,51 @@ export default function useChromeStorage() {
   async function loadPrompts() {
     if (loaded.value) return; // 이미 로드된 경우 실행하지 않음
     try {
-      const initData = await get("hasUsedBefore");
-      const data = await get("prompts");
+      const hasUsedBefore = await get("hasUsedBefore");
+      const loadedPrompts = await get("prompts");
       const isFirstUse =
-        !initData.hasUsedBefore && (!data.prompts || data.prompts.length === 0);
+        !hasUsedBefore && (!loadedPrompts || loadedPrompts.length === 0);
       if (isFirstUse) {
         // 첫 사용이고 저장된 프롬프트가 없을 경우 기본 예제 추가
         let defaultPrompts;
         if (getLocale() === "ko" || getLocale() === "ko-KR") {
           defaultPrompts = [
-            "(샘플) 다음 텍스트를 {언어}로 번역해주세요:\n{텍스트}",
-            "(샘플) {문제 상황}에서 {선택지1}, {선택지2} 중 하나를 선택하는 데 도움을 주세요. 각 선택의 장단점을 비교해주세요.",
-            "(샘플) {제품명}의 {타겟 시장}을 위한 효과적인 마케팅 전략을 작성해주세요.\n주요 목표는 {목표}입니다.",
+            {
+              title: "예시 1",
+              text: "(샘플) 다음 텍스트를 {언어}로 번역해주세요:\n{텍스트}",
+            },
+            {
+              title: "예시 2",
+              text: "(샘플) {문제 상황}에서 {선택지1}, {선택지2} 중 하나를 선택하는 데 도움을 주세요. 각 선택의 장단점을 비교해주세요.",
+            },
+            {
+              title: "예시 3",
+              text: "(샘플) {제품명}의 {타겟 시장}을 위한 효과적인 마케팅 전략을 작성해주세요.\n주요 목표는 {목표}입니다.",
+            },
           ];
         } else {
           defaultPrompts = [
-            "(Sample) Please translate the following text into {language}:\n{text}",
-            "(Sample) Please help choose between {option1} and {option2} in the context of {situation}. Compare the pros and cons of each option.",
-            "(Sample) Write an effective marketing strategy for {product} targeting the {target market}. The main goal is {goal}.",
+            {
+              title: "Sample 1",
+              text: "(Sample) Please translate the following text into {language}:\n{text}",
+            },
+            {
+              title: "Sample 2",
+              text: "(Sample) Please help choose between {option1} and {option2} in the context of {situation}. Compare the pros and cons of each option.",
+            },
+            {
+              title: "Sample 3",
+              text: "(Sample) Write an effective marketing strategy for {product} targeting the {target market}. The main goal is {goal}.",
+            },
           ];
         }
         prompts.value = defaultPrompts;
         await set({ prompts: defaultPrompts, hasUsedBefore: true });
       } else {
-        if (Array.isArray(data.prompts)) {
-          prompts.value = data.prompts;
+        if (Array.isArray(loadedPrompts)) {
+          prompts.value = loadedPrompts;
         } else {
-          prompts.value = data.prompts ? Object.values(data.prompts) : [];
+          prompts.value = loadedPrompts ? Object.values(loadedPrompts) : [];
         }
       }
       loaded.value = true; // 데이터 로딩 완료 표시

--- a/src/utils/promptConverter.js
+++ b/src/utils/promptConverter.js
@@ -3,7 +3,6 @@ import { nanoid } from "nanoid";
 function updateInitialVersion(promptData, idx) {
   // 초기 버전의 promptData를 최신 버전으로 변환
   return {
-    id: nanoid(),
     title: `#${idx + 1}`,
     text: promptData,
   };

--- a/src/utils/promptConverter.js
+++ b/src/utils/promptConverter.js
@@ -1,0 +1,53 @@
+import { nanoid } from "nanoid";
+
+function updateInitialVersion(promptData, idx) {
+  // 초기 버전의 promptData를 최신 버전으로 변환
+  return {
+    id: nanoid(),
+    title: `#${idx + 1}`,
+    text: promptData,
+  };
+}
+
+export function updatePrompt(promptData, idx) {
+  // 이전 버전의 프롬프트 데이터를 최신화
+  if (typeof promptData === "string") {
+    // 초기 버전인 경우
+    return updateInitialVersion(promptData, idx);
+  }
+  return promptData;
+}
+
+export function addId(promptData) {
+  return {
+    ...promptData,
+    id: nanoid(),
+  };
+}
+
+export function convertPromptToExport(promptData) {
+  // 프롬프트를 export 용으로 변환
+  return {
+    title: promptData.title,
+    text: promptData.text,
+  };
+}
+
+export function convertPromptToStore(promptData) {
+  // 프롬프트를 저장용으로 변환
+  return {
+    title: promptData.title,
+    text: promptData.text,
+  };
+}
+
+export function convertImportedPrompt(promptData, idx) {
+  // import 된 데이터를 사용할 수 있도록 변환
+  if (typeof promptData === "object") {
+    return promptData;
+  }
+  if (typeof promptData === "string") {
+    return updateInitialVersion(promptData, idx);
+  }
+  return promptData;
+}


### PR DESCRIPTION
Close #33 

- 프롬프트 데이터에 제목 추가
  - title 이 추가되면서 프롬프트 타입이 `string[]`에서 `{title: string, text: string}[]`로 바뀌었습니다
  - 추가 삭제 등 프롬프트를 처리하는 과정도 바뀐 타입에 맞게 수정했습니다
- util에 promptConverter를 추가
  - 프롬프트 형식이 바뀌면서 하위호환을 위한 변경이나 여러 용도에 따라 필요한 변환, id 추가와 같은 프롬프트 처리에 대한 함수를 따로 분리했습니다
- [nanoid](https://github.com/ai/nanoid) 추가
  - id용으로 사용하려고 추가했습니다. `Date.now()`는 겹치는 경우도 있고 index는 순서가 바뀌기 때문에 부적절하다고 생각해서 지금 문제가 있지는 않지만 무작위 id가 좋을 것 같아 nanoid를 사용하도록 바꿨습니다
- `useChromeStorage.get` 반환값 변경
  - 이전에는 `get(key)`를 하면 해당 key만 포함된 객체가 반환되었습니다.
  - 그러다보니 값을 사용하기 위해서 key로 한번 더 가져오는 과정이 필요한데 이게 불필요하다고 생각되어서 `get(key)`가 바로 값을 반환하도록 변경했습니다

+) prompt 데이터 타입이 자주 바뀌진 않겠죠? 자주 바뀔 수 있다면 지금부터 버전을 추가하는 것도 좋을 수 있을 것 같습니다
++) 익스텐션이다보니 디버깅이 좀 불편한데 typescript로 타입을 정해서 사용해보는건 어떻게 생각하시나요?