### PR TITLE
Feature/#35 여러 OS간 동일한 UI 제공을 위한 무료 웹폰트 추가

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   display: flex;
   align-items: center;
   justify-content: center;
+  font-weight: bold;
+  font-size: 1.4em;
 }
 
 .tab-item i {

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,5 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css");
 body {
     margin: 0;
+    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 }


### PR DESCRIPTION
### 변경 사항
- 무료 상업 목적 이용 가능한 폰트인 `프리텐다드`를 사용하도록 변경
- 탭 라벨의 폰트 크기를 키우고 (1.4em) 및 bold로 변경

#### 적용 결과
![스크린샷 2024-12-26 오후 9 01 26](https://github.com/user-attachments/assets/fc7fd419-d8ca-48aa-8e1f-aaf1593d8f34)

### To reviewers
- 프리텐다드와 프리젠테이션 사이에서 고민하다가 프리젠테이션은 다운로드만 제공하는 반면 프리텐다드는 cdn을 통한 웹폰트를 제공하고 있어서 관리 측면에서 프리텐다드가 더 낫겠다 싶어 프리텐다드로 선택했습니다.
- 웹폰트 사용은 프리텐다드의 깃헙에 설명되어있는 [가변 다이나믹 프리셋](https://github.com/orioncactus/pretendard?tab=readme-ov-file#%EA%B0%80%EB%B3%80-%EB%8B%A4%EC%9D%B4%EB%82%98%EB%AF%B9-%EC%84%9C%EB%B8%8C%EC%85%8B) 방식을 선택했습니다.
- 또한 해당 폰트를 사용하지 못하는 경우 시스템 폰트를 사용하도록 설정해두었습니다.

