### PR TITLE
프롬프트 바로 사용기능 추가

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -56,6 +56,9 @@
     "editLabel": {
         "message": "Edit"
     },
+    "usePromptLabel": {
+        "message": "Use"
+    },
     "duplicateLabel": {
         "message": "Duplicate"
     },

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -56,6 +56,9 @@
     "editLabel": {
         "message": "편집"
     },
+    "usePromptLabel": {
+        "message": "사용"
+    },
     "duplicateLabel": {
         "message": "복제"
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="tab-content">
-    <MainPage v-if="activeIndex === 0" ref="MainPage" />
+    <MainPage v-if="activeIndex === 0" ref="mainPage" />
     <PromptManagementPage
       v-else
       ref="promptManagementPage"
@@ -36,7 +36,7 @@ import { PromptDataWithId } from "./types/prompt";
 
 const activeIndex = ref(0);
 const promptManagementPage = useTemplateRef("promptManagementPage");
-const mainPage = useTemplateRef("MainPage");
+const mainPage = useTemplateRef("mainPage");
 
 const isChromeRuntimeAvailable = ref(
   typeof chrome !== "undefined" && chrome.runtime !== undefined,

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,8 +19,12 @@
     </div>
   </div>
   <div class="tab-content">
-    <MainPage v-if="activeIndex === 0" />
-    <PromptManagementPage v-else ref="promptManagementPage" />
+    <MainPage v-if="activeIndex === 0" ref="MainPage" />
+    <PromptManagementPage
+      v-else
+      ref="promptManagementPage"
+      @use-prompt="onUsePrompt"
+    />
   </div>
 </template>
 
@@ -28,13 +32,24 @@
 import MainPage from "./components/MainPage.vue";
 import PromptManagementPage from "./components/PromptManagementPage.vue";
 import { nextTick, onMounted, ref, useTemplateRef } from "vue";
+import { PromptDataWithId } from "./types/prompt";
 
 const activeIndex = ref(0);
 const promptManagementPage = useTemplateRef("promptManagementPage");
+const mainPage = useTemplateRef("MainPage");
 
 const isChromeRuntimeAvailable = ref(
   typeof chrome !== "undefined" && chrome.runtime !== undefined,
 );
+
+function onUsePrompt(prompt: PromptDataWithId) {
+  activeIndex.value = 0;
+  nextTick(() => {
+    if (mainPage.value) {
+      mainPage.value.usePrompt(prompt);
+    }
+  });
+}
 
 onMounted(() => {
   if (isChromeRuntimeAvailable.value) {

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -100,202 +100,201 @@
   </div>
 </template>
 
-<script lang="ts">
-import { computed, reactive, ref, watch, onMounted } from "vue";
+<script setup lang="ts">
+import {
+  computed,
+  reactive,
+  ref,
+  watch,
+  onMounted,
+  defineComponent,
+  nextTick,
+} from "vue";
 import { useToast } from "primevue/usetoast";
 import useChromeStorage from "../composables/useChromeStorage";
 import useI18n from "../composables/useChromeI18n";
 import { getStringBytes } from "../utils/stringUtils";
-import { addId } from "../utils/promptConverter";
 import { Model, ModelOption, ModelSeparator } from "../types/models";
+import { PromptDataWithId } from "../types/prompt";
 
-export default {
-  name: "MainPage",
-  setup() {
-    const storage = useChromeStorage();
-    const { getMessage } = useI18n();
-    const toast = useToast();
-    const selectedPromptId = ref<string | null>(null);
-    const variables = ref<string[]>([]);
-    const userInputs = reactive<Record<string, string>>({});
-    const filledPrompt = ref("");
-    const selectedModel = ref<Model>("gpt-4"); // 기본 값 설정
-    const urlLengthAlert = ref(false);
+defineComponent({ name: "MainPage" });
 
-    // 모델 옵션들
-    const modelOptions = (
-      [
-        { label: "ChatGPT 4o", model: "gpt-4o" },
-        { label: "ChatGPT o1", model: "o1" },
-        { label: "ChatGPT o1-mini", model: "o1-mini" },
-        { label: "ChatGPT 4o mini", model: "gpt-4o-mini" },
-        { label: "ChatGPT 4", model: "gpt-4" },
-        { separator: true },
-        { label: "Claude 3.5 Sonnet", model: "Claude 3.5 Sonnet" },
-        { separator: true },
-        { label: "Perplexity", model: "Perplexity" },
-      ] as Array<ModelOption | ModelSeparator>
-    ).map((option) => {
-      if ("separator" in option) {
-        return { separator: true };
-      }
-      return {
-        ...option,
-        command: () => selectModel(option.model), // command를 동적으로 생성
-      };
+const storage = useChromeStorage();
+const { getMessage } = useI18n();
+const toast = useToast();
+const selectedPromptId = ref<string | null>(null);
+const variables = ref<string[]>([]);
+const userInputs = reactive<Record<string, string>>({});
+const filledPrompt = ref("");
+const selectedModel = ref<Model>("gpt-4"); // 기본 값 설정
+const urlLengthAlert = ref(false);
+
+const prompts = computed(() => {
+  return storage.prompts.value;
+});
+
+// 모델 옵션들
+const modelOptions = (
+  [
+    { label: "ChatGPT 4o", model: "gpt-4o" },
+    { label: "ChatGPT o1", model: "o1" },
+    { label: "ChatGPT o1-mini", model: "o1-mini" },
+    { label: "ChatGPT 4o mini", model: "gpt-4o-mini" },
+    { label: "ChatGPT 4", model: "gpt-4" },
+    { separator: true },
+    { label: "Claude 3.5 Sonnet", model: "Claude 3.5 Sonnet" },
+    { separator: true },
+    { label: "Perplexity", model: "Perplexity" },
+  ] as Array<ModelOption | ModelSeparator>
+).map((option) => {
+  if ("separator" in option) {
+    return { separator: true };
+  }
+  return {
+    ...option,
+    command: () => selectModel(option.model), // command를 동적으로 생성
+  };
+});
+
+// 버튼 클래스 계산
+const getButtonClass = computed(() => {
+  const model = selectedModel.value.toLowerCase();
+  if (model.includes("claude")) {
+    return "p-button-claude";
+  } else if (model.includes("perplexity")) {
+    return "p-button-perplexity";
+  } else {
+    return "p-button-primary";
+  }
+});
+
+// 모델 선택 함수
+const selectModel = (model: Model): void => {
+  storage
+    .set({ selectedModel: model })
+    .then(() => {
+      selectedModel.value = model;
+    })
+    .catch((error) => {
+      console.error("Failed to save selected model:", error);
+      toast.add({
+        severity: "error",
+        summary: getMessage("error"),
+        detail: getMessage("storageSyncErrorMessage"),
+        life: 5000,
+      });
     });
-
-    // 버튼 클래스 계산
-    const getButtonClass = computed(() => {
-      const model = selectedModel.value.toLowerCase();
-      if (model.includes("claude")) {
-        return "p-button-claude";
-      } else if (model.includes("perplexity")) {
-        return "p-button-perplexity";
-      } else {
-        return "p-button-primary";
-      }
-    });
-
-    // 모델 선택 함수
-    const selectModel = (model: Model): void => {
-      storage
-        .set({ selectedModel: model })
-        .then(() => {
-          selectedModel.value = model;
-        })
-        .catch((error) => {
-          console.error("Failed to save selected model:", error);
-          toast.add({
-            severity: "error",
-            summary: getMessage("error"),
-            detail: getMessage("storageSyncErrorMessage"),
-            life: 5000,
-          });
-        });
-    };
-
-    // 모델의 라벨을 가져오는 함수
-    const getModelLabel = (model: Model): string => {
-      const option = modelOptions.find(
-        (option) => "model" in option && option?.model === model,
-      );
-      return option && "label" in option ? option.label : model;
-    };
-
-    // 컴포넌트가 마운트될 때 모델을 스토리지에서 불러옴
-    onMounted(() => {
-      storage
-        .get("selectedModel")
-        .then((model) => {
-          if (model) {
-            selectedModel.value = model;
-          }
-        })
-        .catch((error) => {
-          console.error("Failed to load selected model:", error);
-        });
-    });
-
-    const prompts = computed(() => {
-      return storage.prompts.value.map(addId);
-    });
-
-    function findPromptById(id: string) {
-      return prompts.value.find((prompt) => prompt.id === id);
-    }
-
-    watch(selectedPromptId, (selectedPromptId) => {
-      if (selectedPromptId) {
-        const newPrompt = findPromptById(selectedPromptId)?.text ?? "";
-        const varMatches = newPrompt.match(/{(.*?)}/g);
-        variables.value = varMatches
-          ? [...new Set(varMatches.map((v) => v.replace(/[{}]/g, "")))]
-          : [];
-        variables.value.forEach((variable) => {
-          userInputs[variable] = "";
-        });
-        filledPrompt.value = "";
-      } else {
-        variables.value = [];
-      }
-    });
-
-    function escapeRegExp(string: string) {
-      return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    }
-
-    const generatePrompt = () => {
-      if (selectedPromptId.value) {
-        let tempPrompt = findPromptById(selectedPromptId.value)?.text ?? "";
-        variables.value.forEach((variable) => {
-          const value = userInputs[variable] || "";
-          const escapedVariable = escapeRegExp(variable);
-          tempPrompt = tempPrompt.replace(
-            new RegExp(`\\{${escapedVariable}\\}`, "g"),
-            value,
-          );
-        });
-        filledPrompt.value = tempPrompt;
-        urlLengthAlert.value = getStringBytes(tempPrompt) >= 8000;
-      }
-    };
-
-    const chatWithModel = () => {
-      if (filledPrompt.value) {
-        const encodedPrompt = encodeURIComponent(filledPrompt.value);
-        const model = selectedModel.value.toLowerCase();
-        let url: string;
-
-        if (model.includes("claude")) {
-          url = `https://claude.ai/new?q=${encodedPrompt}`;
-        } else if (model.includes("perplexity")) {
-          url = `https://perplexity.ai/search?q=${encodedPrompt}`;
-        } else {
-          url = `https://chat.openai.com/?model=${model}&q=${encodedPrompt}`;
-        }
-
-        window.open(url, "_blank");
-      }
-    };
-
-    const copyToClipboard = async () => {
-      try {
-        await navigator.clipboard.writeText(filledPrompt.value);
-        toast.add({
-          severity: "success",
-          summary: getMessage("success"),
-          detail: getMessage("copyToClipboardSuccessMessage"),
-          life: 1000,
-        });
-      } catch {
-        toast.add({
-          severity: "error",
-          summary: getMessage("error"),
-          detail: getMessage("copyToClipboardErrorMessage"),
-          life: 5000,
-        });
-      }
-    };
-
-    return {
-      prompts,
-      selectedPromptId,
-      variables,
-      userInputs,
-      generatePrompt,
-      filledPrompt,
-      chatWithModel,
-      copyToClipboard,
-      selectedModel,
-      modelOptions,
-      getButtonClass,
-      getModelLabel,
-      getMessage,
-      urlLengthAlert,
-    };
-  },
 };
+
+// 모델의 라벨을 가져오는 함수
+const getModelLabel = (model: Model): string => {
+  const option = modelOptions.find(
+    (option) => "model" in option && option?.model === model,
+  );
+  return option && "label" in option ? option.label : model;
+};
+
+// 컴포넌트가 마운트될 때 모델을 스토리지에서 불러옴
+onMounted(() => {
+  storage
+    .get("selectedModel")
+    .then((model) => {
+      if (model) {
+        selectedModel.value = model;
+      }
+    })
+    .catch((error) => {
+      console.error("Failed to load selected model:", error);
+    });
+});
+
+function findPromptById(id: string) {
+  return prompts.value.find((prompt) => prompt.id === id);
+}
+
+watch(selectedPromptId, (selectedPromptId) => {
+  if (selectedPromptId) {
+    const newPrompt = findPromptById(selectedPromptId)?.text ?? "";
+    const varMatches = newPrompt.match(/{(.*?)}/g);
+    variables.value = varMatches
+      ? [...new Set(varMatches.map((v) => v.replace(/[{}]/g, "")))]
+      : [];
+    variables.value.forEach((variable) => {
+      userInputs[variable] = "";
+    });
+    filledPrompt.value = "";
+  } else {
+    variables.value = [];
+  }
+});
+
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const generatePrompt = () => {
+  if (selectedPromptId.value) {
+    let tempPrompt = findPromptById(selectedPromptId.value)?.text ?? "";
+    variables.value.forEach((variable) => {
+      const value = userInputs[variable] || "";
+      const escapedVariable = escapeRegExp(variable);
+      tempPrompt = tempPrompt.replace(
+        new RegExp(`\\{${escapedVariable}\\}`, "g"),
+        value,
+      );
+    });
+    filledPrompt.value = tempPrompt;
+    urlLengthAlert.value = getStringBytes(tempPrompt) >= 8000;
+  }
+};
+
+const chatWithModel = () => {
+  if (filledPrompt.value) {
+    const encodedPrompt = encodeURIComponent(filledPrompt.value);
+    const model = selectedModel.value.toLowerCase();
+    let url: string;
+
+    if (model.includes("claude")) {
+      url = `https://claude.ai/new?q=${encodedPrompt}`;
+    } else if (model.includes("perplexity")) {
+      url = `https://perplexity.ai/search?q=${encodedPrompt}`;
+    } else {
+      url = `https://chat.openai.com/?model=${model}&q=${encodedPrompt}`;
+    }
+
+    window.open(url, "_blank");
+  }
+};
+
+const copyToClipboard = async () => {
+  try {
+    await navigator.clipboard.writeText(filledPrompt.value);
+    toast.add({
+      severity: "success",
+      summary: getMessage("success"),
+      detail: getMessage("copyToClipboardSuccessMessage"),
+      life: 1000,
+    });
+  } catch {
+    toast.add({
+      severity: "error",
+      summary: getMessage("error"),
+      detail: getMessage("copyToClipboardErrorMessage"),
+      life: 5000,
+    });
+  }
+};
+
+const usePrompt = (prompt: PromptDataWithId) => {
+  selectedPromptId.value = prompt.id;
+  setTimeout(() => {
+    generatePrompt();
+  }, 100);
+};
+
+defineExpose({
+  usePrompt,
+});
 </script>
 
 <style scoped>

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -211,8 +211,9 @@ function findPromptById(id: string) {
   return prompts.value.find((prompt) => prompt.id === id);
 }
 
-watch(selectedPromptId, (selectedPromptId) => {
+watch(selectedPromptId, async (selectedPromptId) => {
   if (selectedPromptId) {
+    await storage.loadPrompts();
     const newPrompt = findPromptById(selectedPromptId)?.text ?? "";
     const varMatches = newPrompt.match(/{(.*?)}/g);
     variables.value = varMatches

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -287,9 +287,6 @@ const copyToClipboard = async () => {
 
 const usePrompt = (prompt: PromptDataWithId) => {
   selectedPromptId.value = prompt.id;
-  setTimeout(() => {
-    generatePrompt();
-  }, 100);
 };
 
 defineExpose({

--- a/src/components/MainPage.vue
+++ b/src/components/MainPage.vue
@@ -108,7 +108,6 @@ import {
   watch,
   onMounted,
   defineComponent,
-  nextTick,
 } from "vue";
 import { useToast } from "primevue/usetoast";
 import useChromeStorage from "../composables/useChromeStorage";

--- a/src/components/PromptManagementPage.vue
+++ b/src/components/PromptManagementPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="loaded" class="container">
+  <div v-if="storage.loaded" class="container">
     <InputText
       v-model="newTitle"
       class="new-title-input"
@@ -101,6 +101,12 @@
                   <transition name="fade">
                     <div class="prompt-actions">
                       <Button
+                        icon="pi pi-play"
+                        class="use-button"
+                        :aria-label="getMessage('usePromptLabel')"
+                        @click="usePrompt(index)"
+                      />
+                      <Button
                         icon="pi pi-pencil"
                         class="edit-button"
                         :aria-label="getMessage('editLabel')"
@@ -147,8 +153,8 @@
   </div>
 </template>
 
-<script lang="ts">
-import { ref, useTemplateRef } from "vue";
+<script setup lang="ts">
+import { defineComponent, ref, toRaw, useTemplateRef } from "vue";
 import { useToast } from "primevue/usetoast";
 import useChromeStorage from "../composables/useChromeStorage";
 import useI18n from "../composables/useChromeI18n";
@@ -166,325 +172,304 @@ import {
   PromptDataWithId,
 } from "../types/prompt";
 
-export default {
-  name: "PromptManagementPage",
-  setup() {
-    const storage = useChromeStorage();
-    const { getMessage } = useI18n();
-    const newTitle = ref("");
-    const newPrompt = ref("");
-    const editedTitle = ref("");
-    const editedPrompt = ref("");
-    const editingIndex = ref(-1);
-    const fileInput = useTemplateRef<HTMLInputElement>("fileInput");
-    const dialogVisible = ref(false);
-    const importedPrompts = ref<Array<InitialPromptData | PromptData>>([]);
-    const hoveredIndex = ref(-1);
+defineComponent({ name: "PromptManagementPage" });
+const emit = defineEmits<{
+  (e: "usePrompt", payload: PromptDataWithId): void;
+}>();
 
-    const toast = useToast();
+const storage = useChromeStorage();
+const { getMessage } = useI18n();
+const newTitle = ref("");
+const newPrompt = ref("");
+const editedTitle = ref("");
+const editedPrompt = ref("");
+const editingIndex = ref(-1);
+const fileInput = useTemplateRef<HTMLInputElement>("fileInput");
+const dialogVisible = ref(false);
+const importedPrompts = ref<Array<InitialPromptData | PromptData>>([]);
+const hoveredIndex = ref(-1);
 
-    const prompts = ref<PromptDataWithId[]>([]);
+const toast = useToast();
 
-    // 데이터 로드 완료 상태
-    storage.loadPrompts().then(() => {
-      prompts.value = storage.prompts.value.map(updatePrompt).map(addId);
+const prompts = ref<PromptDataWithId[]>([]);
+
+// 데이터 로드 완료 상태
+storage.loadPrompts().then(() => {
+  prompts.value = storage.prompts.value.map(updatePrompt).map(addId);
+});
+
+const menuItems = [
+  {
+    label: getMessage("exportPrompt"),
+    icon: "pi pi-download",
+    command: () => exportPrompts(),
+  },
+  {
+    label: getMessage("importPrompt"),
+    icon: "pi pi-upload",
+    command: () => fileInput.value?.click(),
+  },
+];
+
+const addPrompt = () => {
+  if (newPrompt.value.trim() && newTitle.value.trim()) {
+    const newPromptObj = {
+      id: nanoid(),
+      text: newPrompt.value.trim(),
+      title: newTitle.value.trim(),
+    };
+    const newPrompts = prompts.value.concat(newPromptObj);
+
+    updateStorePrompts(newPrompts, getMessage("addPromptMessage"))
+      .then(() => {
+        prompts.value.push(newPromptObj);
+        console.log("Prompt added successfully");
+      })
+      .catch((error) => {
+        console.error("Failed to add prompt:", error);
+      });
+    newPrompt.value = "";
+    newTitle.value = "";
+  }
+};
+
+const usePrompt = (index: number) => {
+  const prompt = toRaw(prompts.value[index]);
+  emit("usePrompt", prompt);
+};
+
+const editPrompt = (index: number) => {
+  editingIndex.value = index;
+  editedPrompt.value = prompts.value[index].text;
+  editedTitle.value = prompts.value[index].title;
+};
+
+const saveEditedPrompt = (index: number) => {
+  if (editingIndex.value > -1 && editedPrompt.value.trim()) {
+    const updatedPrompt = {
+      ...prompts.value[index],
+      text: editedPrompt.value.trim(),
+      title: editedTitle.value.trim(),
+    };
+    const newPrompts = prompts.value.slice();
+    newPrompts.splice(index, 1, updatedPrompt);
+
+    updateStorePrompts(newPrompts, getMessage("updatePromptMessage"))
+      .then(() => {
+        prompts.value[index] = updatedPrompt;
+        editingIndex.value = -1;
+        console.log("Prompt updated successfully");
+      })
+      .catch((error) => {
+        console.error("Failed to update prompt:", error);
+      });
+  }
+};
+
+const cancelEdit = () => {
+  editingIndex.value = -1; // 편집 모드 종료
+  editedPrompt.value = ""; // 수정 중인 프롬프트 초기화
+  editedTitle.value = ""; // 수정 중인 프롬프트 초기화
+};
+
+const deletePrompt = (index: number) => {
+  const newPrompts = prompts.value.slice();
+  newPrompts.splice(index, 1);
+
+  updateStorePrompts(newPrompts, getMessage("deletePromptMessage"))
+    .then(() => {
+      prompts.value.splice(index, 1);
+      console.log("Prompt deleted successfully");
+    })
+    .catch((error) => {
+      console.error("Failed to delete prompt:", error);
     });
+};
 
-    const menuItems = [
-      {
-        label: getMessage("exportPrompt"),
-        icon: "pi pi-download",
-        command: () => exportPrompts(),
-      },
-      {
-        label: getMessage("importPrompt"),
-        icon: "pi pi-upload",
-        command: () => fileInput.value?.click(),
-      },
+const duplicatePrompt = (index: number) => {
+  const promptToDuplicate = {
+    ...prompts.value[index],
+    id: nanoid(),
+  };
+  const newPrompts = prompts.value.slice();
+  newPrompts.splice(index + 1, 0, promptToDuplicate);
+
+  updateStorePrompts(newPrompts, getMessage("duplicatePromptMessage"))
+    .then(() => {
+      prompts.value.splice(index + 1, 0, promptToDuplicate);
+      console.log("Prompt duplicated successfully");
+    })
+    .catch((error) => {
+      console.error("Failed to duplicate prompt:", error);
+    });
+};
+
+const exportPrompts = () => {
+  const dataStr = JSON.stringify(
+    prompts.value.map(convertPromptToExport),
+    null,
+    2,
+  );
+  const blob = new Blob([dataStr], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  const now = new Date();
+  const timestamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(
+    now.getDate(),
+  ).padStart(2, "0")}${String(now.getHours()).padStart(2, "0")}${String(
+    now.getMinutes(),
+  ).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`; // 타임스탬프 생성
+  a.href = url;
+  a.download = `prompts_${timestamp}.json`; // 파일 이름에 타임스탬프 추가
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+const showJsonValidationError = () => {
+  toast.add({
+    severity: "error",
+    summary: getMessage("error"),
+    detail: getMessage("jsonValidationErrorMessage"),
+    life: 5000,
+  });
+};
+const onFileChange = (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = (e: ProgressEvent<FileReader>) => {
+      if (!e.target?.result) {
+        showJsonValidationError();
+        return;
+      }
+      const parsedPrompts = JSON.parse(e.target.result as string);
+      if (!Array.isArray(parsedPrompts)) {
+        showJsonValidationError();
+        return;
+      }
+      importedPrompts.value = parsedPrompts;
+      dialogVisible.value = true; // 대화창 표시
+    };
+    reader.readAsText(file);
+  }
+  // 파일 입력 요소 초기화
+  input.value = null;
+};
+
+const overwritePrompts = () => {
+  const newPrompts = importedPrompts.value
+    .map(convertImportedPrompt)
+    .map(addId);
+
+  updateStorePrompts(newPrompts, getMessage("overwritePromptMessage"))
+    .then(() => {
+      prompts.value = newPrompts;
+      console.log("Prompts overwritten successfully");
+    })
+    .catch((error) => {
+      console.error("Failed to overwrite prompts:", error);
+    });
+  dialogVisible.value = false;
+};
+
+const appendPrompts = () => {
+  const importedWithIds = importedPrompts.value
+    .map(convertImportedPrompt)
+    .map(addId);
+  const newPrompts = prompts.value.concat(importedWithIds);
+
+  updateStorePrompts(newPrompts, getMessage("appendPromptMessage"))
+    .then(() => {
+      prompts.value = newPrompts;
+      console.log("Prompts appended successfully");
+    })
+    .catch((error) => {
+      console.error("Failed to append prompts:", error);
+    });
+  dialogVisible.value = false;
+};
+
+const movePromptUp = (index: number) => {
+  if (index > 0) {
+    const newPrompts = prompts.value.slice();
+    [newPrompts[index - 1], newPrompts[index]] = [
+      newPrompts[index],
+      newPrompts[index - 1],
     ];
 
-    const addPrompt = () => {
-      if (newPrompt.value.trim() && newTitle.value.trim()) {
-        const newPromptObj = {
-          id: nanoid(),
-          text: newPrompt.value.trim(),
-          title: newTitle.value.trim(),
-        };
-        const newPrompts = prompts.value.concat(newPromptObj);
-
-        updateStorePrompts(newPrompts, getMessage("addPromptMessage"))
-          .then(() => {
-            prompts.value.push(newPromptObj);
-            console.log("Prompt added successfully");
-          })
-          .catch((error) => {
-            console.error("Failed to add prompt:", error);
-          });
-        newPrompt.value = "";
-        newTitle.value = "";
-      }
-    };
-
-    const editPrompt = (index: number) => {
-      editingIndex.value = index;
-      editedPrompt.value = prompts.value[index].text;
-      editedTitle.value = prompts.value[index].title;
-    };
-
-    const saveEditedPrompt = (index: number) => {
-      if (editingIndex.value > -1 && editedPrompt.value.trim()) {
-        const updatedPrompt = {
-          ...prompts.value[index],
-          text: editedPrompt.value.trim(),
-          title: editedTitle.value.trim(),
-        };
-        const newPrompts = prompts.value.slice();
-        newPrompts.splice(index, 1, updatedPrompt);
-
-        updateStorePrompts(newPrompts, getMessage("updatePromptMessage"))
-          .then(() => {
-            prompts.value[index] = updatedPrompt;
-            editingIndex.value = -1;
-            console.log("Prompt updated successfully");
-          })
-          .catch((error) => {
-            console.error("Failed to update prompt:", error);
-          });
-      }
-    };
-
-    const cancelEdit = () => {
-      editingIndex.value = -1; // 편집 모드 종료
-      editedPrompt.value = ""; // 수정 중인 프롬프트 초기화
-      editedTitle.value = ""; // 수정 중인 프롬프트 초기화
-    };
-
-    const deletePrompt = (index: number) => {
-      const newPrompts = prompts.value.slice();
-      newPrompts.splice(index, 1);
-
-      updateStorePrompts(newPrompts, getMessage("deletePromptMessage"))
-        .then(() => {
-          prompts.value.splice(index, 1);
-          console.log("Prompt deleted successfully");
-        })
-        .catch((error) => {
-          console.error("Failed to delete prompt:", error);
-        });
-    };
-
-    const duplicatePrompt = (index: number) => {
-      const promptToDuplicate = {
-        ...prompts.value[index],
-        id: nanoid(),
-      };
-      const newPrompts = prompts.value.slice();
-      newPrompts.splice(index + 1, 0, promptToDuplicate);
-
-      updateStorePrompts(newPrompts, getMessage("duplicatePromptMessage"))
-        .then(() => {
-          prompts.value.splice(index + 1, 0, promptToDuplicate);
-          console.log("Prompt duplicated successfully");
-        })
-        .catch((error) => {
-          console.error("Failed to duplicate prompt:", error);
-        });
-    };
-
-    const exportPrompts = () => {
-      const dataStr = JSON.stringify(
-        prompts.value.map(convertPromptToExport),
-        null,
-        2,
-      );
-      const blob = new Blob([dataStr], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      const now = new Date();
-      const timestamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(
-        now.getDate(),
-      ).padStart(2, "0")}${String(now.getHours()).padStart(2, "0")}${String(
-        now.getMinutes(),
-      ).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`; // 타임스탬프 생성
-      a.href = url;
-      a.download = `prompts_${timestamp}.json`; // 파일 이름에 타임스탬프 추가
-      a.click();
-      URL.revokeObjectURL(url);
-    };
-
-    const onFileChange = (event: Event) => {
-      const input = event.target as HTMLInputElement;
-      const file = input.files?.[0];
-      if (file) {
-        const reader = new FileReader();
-        reader.onload = (e: ProgressEvent<FileReader>) => {
-          try {
-            if (!e.target?.result) {
-              throw new Error("No result");
-            }
-            const parsedPrompts = JSON.parse(e.target.result as string);
-            if (Array.isArray(parsedPrompts)) {
-              importedPrompts.value = parsedPrompts;
-              dialogVisible.value = true; // 대화창 표시
-            } else {
-              throw new Error("Invalid format");
-            }
-          } catch {
-            toast.add({
-              severity: "error",
-              summary: getMessage("error"),
-              detail: getMessage("jsonValidationErrorMessage"),
-              life: 5000,
-            });
-          }
-        };
-        reader.readAsText(file);
-      }
-      // 파일 입력 요소 초기화
-      input.value = null;
-    };
-
-    const overwritePrompts = () => {
-      const newPrompts = importedPrompts.value
-        .map(convertImportedPrompt)
-        .map(addId);
-
-      updateStorePrompts(newPrompts, getMessage("overwritePromptMessage"))
-        .then(() => {
-          prompts.value = newPrompts;
-          console.log("Prompts overwritten successfully");
-        })
-        .catch((error) => {
-          console.error("Failed to overwrite prompts:", error);
-        });
-      dialogVisible.value = false;
-    };
-
-    const appendPrompts = () => {
-      const importedWithIds = importedPrompts.value
-        .map(convertImportedPrompt)
-        .map(addId);
-      const newPrompts = prompts.value.concat(importedWithIds);
-
-      updateStorePrompts(newPrompts, getMessage("appendPromptMessage"))
-        .then(() => {
-          prompts.value = newPrompts;
-          console.log("Prompts appended successfully");
-        })
-        .catch((error) => {
-          console.error("Failed to append prompts:", error);
-        });
-      dialogVisible.value = false;
-    };
-
-    const movePromptUp = (index: number) => {
-      if (index > 0) {
-        const newPrompts = prompts.value.slice();
-        [newPrompts[index - 1], newPrompts[index]] = [
-          newPrompts[index],
-          newPrompts[index - 1],
+    updateStorePrompts(newPrompts)
+      .then(() => {
+        [prompts.value[index - 1], prompts.value[index]] = [
+          prompts.value[index],
+          prompts.value[index - 1],
         ];
+        console.log("Prompt moved up successfully");
+      })
+      .catch((error) => {
+        console.error("Failed to move prompt up:", error);
+      });
+  }
+};
 
-        updateStorePrompts(newPrompts)
-          .then(() => {
-            [prompts.value[index - 1], prompts.value[index]] = [
-              prompts.value[index],
-              prompts.value[index - 1],
-            ];
-            console.log("Prompt moved up successfully");
-          })
-          .catch((error) => {
-            console.error("Failed to move prompt up:", error);
-          });
-      }
-    };
+const movePromptDown = (index: number) => {
+  if (index < prompts.value.length - 1) {
+    const newPrompts = prompts.value.slice();
+    [newPrompts[index], newPrompts[index + 1]] = [
+      newPrompts[index + 1],
+      newPrompts[index],
+    ];
 
-    const movePromptDown = (index: number) => {
-      if (index < prompts.value.length - 1) {
-        const newPrompts = prompts.value.slice();
-        [newPrompts[index], newPrompts[index + 1]] = [
-          newPrompts[index + 1],
-          newPrompts[index],
+    updateStorePrompts(newPrompts)
+      .then(() => {
+        [prompts.value[index], prompts.value[index + 1]] = [
+          prompts.value[index + 1],
+          prompts.value[index],
         ];
+        console.log("Prompt moved down successfully");
+      })
+      .catch((error) => {
+        console.error("Failed to move prompt down:", error);
+      });
+  }
+};
 
-        updateStorePrompts(newPrompts)
-          .then(() => {
-            [prompts.value[index], prompts.value[index + 1]] = [
-              prompts.value[index + 1],
-              prompts.value[index],
-            ];
-            console.log("Prompt moved down successfully");
-          })
-          .catch((error) => {
-            console.error("Failed to move prompt down:", error);
-          });
-      }
-    };
-
-    const updateStorePrompts = async (
-      newPrompts: PromptData[],
-      message?: string,
-    ) => {
-      const promptsTexts = newPrompts.map(convertPromptToStore);
-      try {
-        await storage.set({ prompts: promptsTexts });
-        storage.prompts.value = promptsTexts;
-        if (message) {
-          toast.add({
-            severity: "success",
-            summary: getMessage("success"),
-            detail: message,
-            life: 1000,
-          });
-        }
-      } catch (error) {
-        console.error("Storage set error:", error);
-        toast.add({
-          severity: "error",
-          summary: getMessage("error"),
-          detail: getMessage("storageSyncErrorMessage"),
-          life: 5000,
-        });
-        throw error;
-      }
-    };
-
-    function handleAddPromptFromContext(prompt: string) {
-      storage.loadPrompts().then(() => {
-        newPrompt.value = prompt;
+const updateStorePrompts = async (
+  newPrompts: PromptData[],
+  message?: string,
+) => {
+  const promptsTexts = newPrompts.map(convertPromptToStore);
+  try {
+    await storage.set({ prompts: promptsTexts });
+    if (message) {
+      toast.add({
+        severity: "success",
+        summary: getMessage("success"),
+        detail: message,
+        life: 1000,
       });
     }
-
-    return {
-      prompts,
-      newTitle,
-      newPrompt,
-      addPrompt,
-      editPrompt,
-      saveEditedPrompt,
-      cancelEdit,
-      deletePrompt,
-      duplicatePrompt,
-      exportPrompts,
-      onFileChange,
-      overwritePrompts,
-      appendPrompts,
-      editedTitle,
-      editedPrompt,
-      editingIndex,
-      menuItems,
-      fileInput,
-      dialogVisible,
-      importedPrompts,
-      movePromptUp,
-      movePromptDown,
-      hoveredIndex,
-      loaded: storage.loaded,
-      getMessage,
-      handleAddPromptFromContext,
-    };
-  },
+  } catch (error) {
+    console.error("Storage set error:", error);
+    toast.add({
+      severity: "error",
+      summary: getMessage("error"),
+      detail: getMessage("storageSyncErrorMessage"),
+      life: 5000,
+    });
+    throw error;
+  }
 };
+
+function handleAddPromptFromContext(prompt: string) {
+  storage.loadPrompts().then(() => {
+    newPrompt.value = prompt;
+  });
+}
+
+defineExpose({
+  handleAddPromptFromContext,
+});
 </script>
 
 <style scoped>
@@ -585,7 +570,7 @@ export default {
 
 .prompt-actions {
   display: flex;
-  gap: 1rem;
+  gap: 0.75rem;
   justify-content: center;
   opacity: 0;
   transition: opacity 0.3s ease;

--- a/src/composables/useChromeStorage.ts
+++ b/src/composables/useChromeStorage.ts
@@ -1,13 +1,13 @@
 import { ref } from "vue";
 import useI18n from "./useChromeI18n";
-import { PromptData } from "../types/prompt";
+import { PromptData, PromptDataWithId } from "../types/prompt";
 import { StoredData } from "../types/storage";
-import { updatePrompt } from "../utils/promptConverter";
+import { addId, updatePrompt } from "../utils/promptConverter";
 
 export default function useChromeStorage() {
   const { getLocale } = useI18n();
 
-  const prompts = ref<PromptData[]>([]);
+  const prompts = ref<PromptDataWithId[]>([]);
   const loaded = ref(false);
   const isChromeStorageAvailable = ref<boolean>(
     typeof chrome !== "undefined" && chrome.storage !== undefined,
@@ -56,6 +56,7 @@ export default function useChromeStorage() {
               JSON.stringify(data[key as keyof StoredData]),
             );
           }
+          loadPrompts();
           resolve();
         } catch (error) {
           reject(error);
@@ -108,11 +109,11 @@ export default function useChromeStorage() {
             },
           ];
         }
-        prompts.value = defaultPrompts;
+        prompts.value = defaultPrompts.map(addId);
       } else {
-        prompts.value = (loadedPrompts ? Object.values(loadedPrompts) : []).map(
-          updatePrompt,
-        );
+        prompts.value = (loadedPrompts ? Object.values(loadedPrompts) : [])
+          .map(updatePrompt)
+          .map(addId);
       }
       await set({ prompts: prompts.value, hasUsedBefore: true });
       loaded.value = true; // 데이터 로딩 완료 표시

--- a/src/types/prompt.ts
+++ b/src/types/prompt.ts
@@ -7,6 +7,7 @@ export type PromptData = {
 export type PromptDataWithId = PromptData & { id: string };
 export type PromptDataSync = {
   // 저장용 prompt 데이터 type
+  id: string;
   title: string;
   text: string;
 };

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,8 +1,8 @@
-import { PromptData } from "./prompt";
+import { PromptDataWithId } from "./prompt";
 import { Model } from "./models";
 
 export type StoredData = {
-  prompts?: PromptData[] | Record<number, PromptData>;
+  prompts?: PromptDataWithId[] | Record<number, PromptDataWithId>;
   selectedModel?: Model;
   hasUsedBefore?: boolean;
 };

--- a/src/utils/promptConverter.ts
+++ b/src/utils/promptConverter.ts
@@ -59,7 +59,8 @@ export function convertPromptToStore(
     return promptData;
   }
   return {
-    ...promptData,
+    title: promptData.title,
+    text: promptData.text,
     id: nanoid(),
   };
 }

--- a/src/utils/promptConverter.ts
+++ b/src/utils/promptConverter.ts
@@ -5,6 +5,7 @@ import {
   PromptData,
   PromptDataExport,
   PromptDataSync,
+  PromptDataWithId,
 } from "../types/prompt";
 
 function updateInitialVersion(
@@ -30,7 +31,10 @@ export function updatePrompt(
   return promptData;
 }
 
-export function addId(promptData: PromptData) {
+export function addId(promptData: PromptData | PromptDataWithId) {
+  if ("id" in promptData) {
+    return promptData;
+  }
   return {
     ...promptData,
     id: nanoid(),
@@ -47,11 +51,16 @@ export function convertPromptToExport(
   };
 }
 
-export function convertPromptToStore(promptData: PromptData): PromptDataSync {
+export function convertPromptToStore(
+  promptData: PromptData | PromptDataWithId,
+): PromptDataSync {
   // 프롬프트를 저장용으로 변환
+  if ("id" in promptData) {
+    return promptData;
+  }
   return {
-    title: promptData.title,
-    text: promptData.text,
+    ...promptData,
+    id: nanoid(),
   };
 }
 


### PR DESCRIPTION
Close #44 

## 변경점
- Manage 페이지의 각 프롬프트에 바로 사용을 위한 버튼을 추가했습니다
  - 클릭하면 App.vue에 이벤트를 보내고, App.vue에서 이벤트를 받으면 Main에 추가된 `usePrompt()`를 호출하는 식으로 구현되어있습니다
- 페이지별로 prompt 목록을 관리하지 않고 모든 페이지에서 useChromeStorage에 있는 prompts를 같이 사용하여 id를 공유하도록 변경
  - 기존에는 구분 용도로만 사용되면 됐어서 페이지마다 프롬프트의 id를 다르게 사용하고 있었는데 페이지끼리 선택한 프롬프트를 공유하는 과정에서 Main 에서 Select를 연동시켜줄 필요가 있었습니다
  - 그러다보니 sync에 저장할 때 id도 같이 저장하는게 용이해서 크롬 스토리지에 저장할 때 id를 추가했습니다
  - addId도 기존에 id가 있는 경우 유지해야하기 때문에 없는 경우만 추가하도록 변경했습니다
- options api를 사용하고 있던 부분을 emit 타이핑 때문에 composition api로 변경했는데 이부분은 보시고 별로면 다시 돌려놓아도 될 것 같아요
- 

## 우려되는 부분
- 메인에서 Select에 선택한 프롬프트의 id를 넣어주고 조합버튼까지 눌러주는 효과를 위해 generatePrompt를 호출하는데 바로 호출하면 selectedPromptId의 watch에 의해 값이 변경되기 전에 호출되어 아무 반응이 없습니다. nextTick을 사용해도 watch 콜백의 종료 이후에 실행을 보장할 수 없어서 우선은 setTimeout으로 watch가 완료될만한 시간을 주어서 구현했습니다