### PR TITLE
Feature/#43 풋터 추가

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -115,5 +115,17 @@
     },
     "contextMenuAddSelectedTextAsPrompt": {
         "message": "Add selected text as a prompt"
+    },
+    "footerReleaseNote": {
+        "message" : "Release Note"
+    },
+    "footerCredits": {
+        "message" : "Credits"
+    },
+    "footerGithub": {
+        "message" : "GitHub Repo"
+    },
+    "footerSupportHub": {
+        "message" : "Support Hub"
     }
 }

--- a/public/_locales/ko/messages.json
+++ b/public/_locales/ko/messages.json
@@ -115,5 +115,17 @@
     },
     "contextMenuAddSelectedTextAsPrompt": {
         "message" : "선택한 텍스트를 프롬프트로 추가"
+    },
+    "footerReleaseNote": {
+        "message" : "릴리즈 노트"
+    },
+    "footerCredits": {
+        "message" : "만든이들"
+    },
+    "footerGithub": {
+        "message" : "GitHub 저장소"
+    },
+    "footerSupportHub": {
+        "message" : "지원 허브"
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,7 @@
       />
     </div>
   </div>
-  <Footer/>
+  <Footer />
 </template>
 
 <script setup lang="ts">

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,31 +1,34 @@
 <template>
   <Toast position="bottom-center" class="promptly-toast" />
-  <div class="custom-tabmenu">
-    <div
-      class="tab-item"
-      :class="{ active: activeIndex === 0 }"
-      @click="activeIndex = 0"
-    >
-      <i class="pi pi-home icon-spacing"></i>
-      <span>MAIN</span>
+  <div class="scroll-area">
+    <div class="custom-tabmenu">
+      <div
+        class="tab-item"
+        :class="{ active: activeIndex === 0 }"
+        @click="activeIndex = 0"
+      >
+        <i class="pi pi-home icon-spacing"></i>
+        <span>MAIN</span>
+      </div>
+      <div
+        class="tab-item"
+        :class="{ active: activeIndex === 1 }"
+        @click="activeIndex = 1"
+      >
+        <i class="pi pi-pencil icon-spacing"></i>
+        <span>MANAGE</span>
+      </div>
     </div>
-    <div
-      class="tab-item"
-      :class="{ active: activeIndex === 1 }"
-      @click="activeIndex = 1"
-    >
-      <i class="pi pi-pencil icon-spacing"></i>
-      <span>MANAGE</span>
+    <div class="tab-content">
+      <MainPage v-if="activeIndex === 0" ref="mainPage" />
+      <PromptManagementPage
+        v-else
+        ref="promptManagementPage"
+        @use-prompt="onUsePrompt"
+      />
     </div>
   </div>
-  <div class="tab-content">
-    <MainPage v-if="activeIndex === 0" ref="mainPage" />
-    <PromptManagementPage
-      v-else
-      ref="promptManagementPage"
-      @use-prompt="onUsePrompt"
-    />
-  </div>
+  <Footer/>
 </template>
 
 <script setup lang="ts">
@@ -33,6 +36,7 @@ import MainPage from "./components/MainPage.vue";
 import PromptManagementPage from "./components/PromptManagementPage.vue";
 import { nextTick, onMounted, ref, useTemplateRef } from "vue";
 import { PromptDataWithId } from "./types/prompt";
+import Footer from "./components/Footer.vue"; // Footer 컴포넌트 임포트
 
 const activeIndex = ref(0);
 const promptManagementPage = useTemplateRef("promptManagementPage");
@@ -73,6 +77,11 @@ onMounted(() => {
   width: 400px;
   overflow: hidden;
   position: relative;
+}
+
+.scroll-area {
+  min-height: 100%;
+  padding-bottom: 30px;
 }
 
 .promptly-toast {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,0 +1,115 @@
+<template>
+  <footer class="app-footer">
+    <div class="footer-content">
+      <div class="footer-left">
+        <!-- promptly + 버전 표시 -->
+        <span class="footer-link">
+          promptly v{{ appVersion }}
+        </span>
+        <!-- 릴리즈 노트 아이콘 -->
+        <a
+            href="https://github.com/cheolm1n/promptly/releases"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="footer-link"
+            v-tooltip.top.top="getMessage('footerReleaseNote')"
+        >
+          <i class="pi pi-info-circle icon"></i>
+        </a>
+      </div>
+      <div class="footer-right">
+        <!-- 만든이들 아이콘 -->
+        <a
+            href="https://sites.google.com/view/promptly-credits"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="footer-link"
+            v-tooltip.top="getMessage('footerCredits')"
+        >
+          <i class="pi pi-id-card icon"></i>
+        </a>
+
+        <!-- 깃헙 아이콘 -->
+        <a
+            href="https://github.com/cheolm1n/promptly"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="footer-link"
+            v-tooltip.top="getMessage('footerGithub')"
+        >
+          <i class="pi pi-github icon"></i>
+        </a>
+
+        <!-- 지원 허브 (Chrome Web Store) 아이콘 -->
+        <a
+            href="https://chromewebstore.google.com/detail/bkbcjoofjhapaicbfnmalldjahceecjd/support"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="footer-link"
+            v-tooltip.top="getMessage('footerSupportHub')"
+        >
+          <i class="pi pi-flag icon"></i>
+        </a>
+      </div>
+    </div>
+  </footer>
+</template>
+
+<script setup lang="ts">
+import useI18n from "../composables/useChromeI18n";
+
+const { getMessage } = useI18n();
+
+const appVersion = __APP_VERSION__;
+</script>
+
+<style scoped>
+.app-footer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: 30px;
+  z-index: 999;
+  display: flex;
+  background-color: white;
+}
+
+.footer-content {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 0.5rem;
+}
+
+.footer-left,
+.footer-right {
+  display: flex;
+  gap: 1rem; /* 아이템 사이 간격 */
+}
+
+/* 아이콘 링크 스타일 */
+.footer-link {
+  color: #666;
+  text-decoration: none;
+  font-size: 1.2rem; /* 아이콘 크기 */
+}
+
+.footer-link:hover {
+  color: #222;
+}
+
+.icon {
+  vertical-align: middle;
+}
+
+@media (prefers-color-scheme: dark) {
+  .app-footer {
+    background-color: #0F0F0F;
+  }
+  .footer-link:hover {
+    color: #888;
+  }
+
+}
+</style>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -6,11 +6,11 @@
         <span class="footer-link"> promptly v{{ appVersion }} </span>
         <!-- 릴리즈 노트 아이콘 -->
         <a
+          v-tooltip.top="getMessage('footerReleaseNote')"
           href="https://github.com/cheolm1n/promptly/releases"
           target="_blank"
           rel="noopener noreferrer"
           class="footer-link"
-          v-tooltip.top="getMessage('footerReleaseNote')"
         >
           <i class="pi pi-info-circle icon"></i>
         </a>
@@ -18,33 +18,33 @@
       <div class="footer-right">
         <!-- 만든이들 아이콘 -->
         <a
+          v-tooltip.top="getMessage('footerCredits')"
           href="https://sites.google.com/view/promptly-credits"
           target="_blank"
           rel="noopener noreferrer"
           class="footer-link"
-          v-tooltip.top="getMessage('footerCredits')"
         >
           <i class="pi pi-id-card icon"></i>
         </a>
 
         <!-- 깃헙 아이콘 -->
         <a
+          v-tooltip.top="getMessage('footerGithub')"
           href="https://github.com/cheolm1n/promptly"
           target="_blank"
           rel="noopener noreferrer"
           class="footer-link"
-          v-tooltip.top="getMessage('footerGithub')"
         >
           <i class="pi pi-github icon"></i>
         </a>
 
         <!-- 지원 허브 (Chrome Web Store) 아이콘 -->
         <a
+          v-tooltip.top="getMessage('footerSupportHub')"
           href="https://chromewebstore.google.com/detail/bkbcjoofjhapaicbfnmalldjahceecjd/support"
           target="_blank"
           rel="noopener noreferrer"
           class="footer-link"
-          v-tooltip.top="getMessage('footerSupportHub')"
         >
           <i class="pi pi-flag icon"></i>
         </a>
@@ -102,7 +102,7 @@ const appVersion = __APP_VERSION__;
 
 @media (prefers-color-scheme: dark) {
   .app-footer {
-    background-color: #0f0f0f;
+    background-color: #121212;
   }
   .footer-link:hover {
     color: #888;

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -90,7 +90,6 @@ const appVersion = __APP_VERSION__;
 .footer-link {
   color: #666;
   text-decoration: none;
-  font-size: 1.2rem; /* 아이콘 크기 */
 }
 
 .footer-link:hover {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,16 +3,14 @@
     <div class="footer-content">
       <div class="footer-left">
         <!-- promptly + 버전 표시 -->
-        <span class="footer-link">
-          promptly v{{ appVersion }}
-        </span>
+        <span class="footer-link"> promptly v{{ appVersion }} </span>
         <!-- 릴리즈 노트 아이콘 -->
         <a
-            href="https://github.com/cheolm1n/promptly/releases"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-link"
-            v-tooltip.top.top="getMessage('footerReleaseNote')"
+          href="https://github.com/cheolm1n/promptly/releases"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="footer-link"
+          v-tooltip.top="getMessage('footerReleaseNote')"
         >
           <i class="pi pi-info-circle icon"></i>
         </a>
@@ -20,33 +18,33 @@
       <div class="footer-right">
         <!-- 만든이들 아이콘 -->
         <a
-            href="https://sites.google.com/view/promptly-credits"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-link"
-            v-tooltip.top="getMessage('footerCredits')"
+          href="https://sites.google.com/view/promptly-credits"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="footer-link"
+          v-tooltip.top="getMessage('footerCredits')"
         >
           <i class="pi pi-id-card icon"></i>
         </a>
 
         <!-- 깃헙 아이콘 -->
         <a
-            href="https://github.com/cheolm1n/promptly"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-link"
-            v-tooltip.top="getMessage('footerGithub')"
+          href="https://github.com/cheolm1n/promptly"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="footer-link"
+          v-tooltip.top="getMessage('footerGithub')"
         >
           <i class="pi pi-github icon"></i>
         </a>
 
         <!-- 지원 허브 (Chrome Web Store) 아이콘 -->
         <a
-            href="https://chromewebstore.google.com/detail/bkbcjoofjhapaicbfnmalldjahceecjd/support"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="footer-link"
-            v-tooltip.top="getMessage('footerSupportHub')"
+          href="https://chromewebstore.google.com/detail/bkbcjoofjhapaicbfnmalldjahceecjd/support"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="footer-link"
+          v-tooltip.top="getMessage('footerSupportHub')"
         >
           <i class="pi pi-flag icon"></i>
         </a>
@@ -105,11 +103,10 @@ const appVersion = __APP_VERSION__;
 
 @media (prefers-color-scheme: dark) {
   .app-footer {
-    background-color: #0F0F0F;
+    background-color: #0f0f0f;
   }
   .footer-link:hover {
     color: #888;
   }
-
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue";
+import {createApp} from "vue";
 import App from "./App.vue";
 import PrimeVue from "primevue/config";
 import Aura from "@primevue/themes/Aura";
@@ -8,43 +8,32 @@ import "./style.css";
 import "primeicons/primeicons.css";
 
 // PrimeVue 컴포넌트 등록
-import {
-  Button,
-  InputText,
-  Textarea,
-  Select,
-  Dialog,
-  ToastService,
-  Toast,
-  SplitButton,
-  Message,
-  Menu,
-} from "primevue";
-import { definePreset } from "@primevue/themes";
+import {Button, Dialog, InputText, Menu, Message, Select, SplitButton, Textarea, Toast, ToastService, Tooltip,} from "primevue";
+import {definePreset} from "@primevue/themes";
 
 const app = createApp(App);
 
 const preset = definePreset(Aura, {
-  semantic: {
-    primary: {
-      50: "{sky.50}",
-      100: "{sky.100}",
-      200: "{sky.200}",
-      300: "{sky.300}",
-      400: "{sky.400}",
-      500: "{sky.500}",
-      600: "{sky.600}",
-      700: "{sky.700}",
-      800: "{sky.800}",
-      900: "{sky.900}",
-      950: "{sky.950}",
+    semantic: {
+        primary: {
+            50: "{sky.50}",
+            100: "{sky.100}",
+            200: "{sky.200}",
+            300: "{sky.300}",
+            400: "{sky.400}",
+            500: "{sky.500}",
+            600: "{sky.600}",
+            700: "{sky.700}",
+            800: "{sky.800}",
+            900: "{sky.900}",
+            950: "{sky.950}",
+        },
     },
-  },
 });
 app.use(PrimeVue, {
-  theme: {
-    preset: preset,
-  },
+    theme: {
+        preset: preset,
+    },
 });
 app.use(ToastService);
 
@@ -58,6 +47,7 @@ app.component("Toast", Toast);
 app.component("SplitButton", SplitButton);
 app.component("Message", Message);
 app.component("Menu", Menu);
+app.directive("Tooltip", Tooltip);
 /* eslint-enable */
 
 app.mount("#app");

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { createHtmlPlugin } from "vite-plugin-html";
 import path from "path";
+import { version } from "./package.json";
+
 
 export default defineConfig({
   plugins: [
@@ -30,5 +32,8 @@ export default defineConfig({
   },
   optimizeDeps: {
     include: ["primevue"],
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
   },
 });


### PR DESCRIPTION
### 변경 사항
- 풋터를 추가했습니다. 
    - 프로그램 이름, 현재 버전, 릴리즈노트, 만든이들, 깃헙 저장소, 지원 센터
- 현재 버전은  `package.json`의 `version`을 가져오도록 하였습니다.
<img width="398" alt="스크린샷 2025-02-02 오후 9 16 22" src="https://github.com/user-attachments/assets/3ee56ab4-0c44-4835-9957-447036646b8e" />
<img width="398" alt="스크린샷 2025-02-02 오후 9 16 30" src="https://github.com/user-attachments/assets/dc11cc88-58d1-4a8d-a548-89c8c9981476" />


### To reviewers
- 풋터 높이를 30px로 잡고 총 높이를 630px로 잡으려고 했으나, 생각해보니 크롬 익스텐션의 최대 높이가 600px이라 어쩔 수 없이 570px (본문) + 30px (풋터) 로 작업하였습니다.
- 이상하게 dark 모드 일 때의 footer의 배경 색을 `0F0F0F` 로 설정했는데,  실제로는 `#0D0D0D`로 보이는 문제가 있네요(?)
- 만든이들을 위해 아래 페이지를 추가하였는데... 뭔가 휑하네요... 이건 사후 수정도 가능하니 좋은 아이디어 있으심 말씀해주세요~ 
    - https://sites.google.com/view/promptly-credits